### PR TITLE
Disable this extension in v2

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -20,5 +20,8 @@
     "public": true,
     "supportedTargets": [
         "microbit"
-    ]
+    ],
+    "disablesVariants": [
+        "mbcodal"
+     ]
 }


### PR DESCRIPTION
This extension doesn't work in the latest makecode. This has dependency on the compilation service which is updated for using v2 hardware. This config change disables compilation for v2 hardware.

Now the extension will work as is for v1 hardware and will fail only for v2 hardware. Fixing the extension for v2 needs additional change in the extension itself.